### PR TITLE
[BE] 특정 카테고리의 베스트 음식 조회 기능 구현

### DIFF
--- a/BE/src/main/java/sidedish/com/controller/ProductsController.java
+++ b/BE/src/main/java/sidedish/com/controller/ProductsController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import sidedish.com.controller.model.ProductDetailTypeResponse;
 import sidedish.com.controller.model.ProductBasicTypeResponse;
+import sidedish.com.controller.model.ProductDetailTypeResponse;
 import sidedish.com.service.ProductsService;
 
 @RestController
@@ -31,7 +31,13 @@ public class ProductsController {
 
 	@GetMapping("/{id}")
 	public ProductDetailTypeResponse findById(@PathVariable @Negative @NotNull Long id) {
-		 return productsService.findById(id);
+		return productsService.findById(id);
+	}
+
+	@GetMapping("/best")
+	public List<ProductBasicTypeResponse> findAllByBestCategory(
+		@RequestParam String category) {
+		return productsService.findAllByBestCategory(category);
 	}
 
 	@GetMapping("/recommendation")

--- a/BE/src/main/java/sidedish/com/domain/DiscountPolicy.java
+++ b/BE/src/main/java/sidedish/com/domain/DiscountPolicy.java
@@ -8,9 +8,9 @@ import lombok.Getter;
 public class DiscountPolicy {
 
 	private String policyName;
-	private float discountRate;
+	private long discountRate;
 
 	public long calculateFixedPrice(long originalPrice) {
-		return (long) (originalPrice * ((100 - discountRate) / 100));
+		return (long) (originalPrice * ((100 - discountRate) / (double) 100));
 	}
 }

--- a/BE/src/main/java/sidedish/com/repository/ProductsRepository.java
+++ b/BE/src/main/java/sidedish/com/repository/ProductsRepository.java
@@ -4,10 +4,8 @@ import java.util.List;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 import sidedish.com.repository.entity.ProductEntity;
 
-@Repository
 public interface ProductsRepository extends CrudRepository<ProductEntity, Long> {
 
 	@Override
@@ -16,4 +14,6 @@ public interface ProductsRepository extends CrudRepository<ProductEntity, Long> 
 	@Query("select id, discount_policy_id, delivery_policy_id, product_name, description, original_price, meal_category "
 		+ "from PRODUCT where meal_category = :mealType")
 	List<ProductEntity> findByMealType(@Param("mealType") String mealType);
+
+	List<ProductEntity> findAllByBestCategory(String category);
 }

--- a/BE/src/main/java/sidedish/com/repository/entity/DiscountPolicyEntity.java
+++ b/BE/src/main/java/sidedish/com/repository/entity/DiscountPolicyEntity.java
@@ -12,10 +12,10 @@ public class DiscountPolicyEntity {
 	@Id
 	private final Long id;
 	private final String policyName;
-	private final float discountRate;
+	private final long discountRate;
 
 	@PersistenceConstructor
-	public DiscountPolicyEntity(Long id, String policyName, float discountRate) {
+	public DiscountPolicyEntity(Long id, String policyName, long discountRate) {
 		this.id = id;
 		this.policyName = policyName;
 		this.discountRate = discountRate;

--- a/BE/src/main/java/sidedish/com/service/ProductsService.java
+++ b/BE/src/main/java/sidedish/com/service/ProductsService.java
@@ -43,15 +43,9 @@ public class ProductsService {
 			discountPolicyRepository.findAll(),
 			deliveryPolicyRepository.findAll());
 
-		validProducts(products);
+		validateProducts(products);
 
 		return productsDtoMapper.toProductsBasicTypeResponseFromDomain(products);
-	}
-
-	private void validProducts(List<Product> products) {
-		if (products.isEmpty()) {
-			throw new NoSuchProductsException();
-		}
 	}
 
 	public ProductDetailTypeResponse findById(Long id) {
@@ -81,12 +75,29 @@ public class ProductsService {
 		return productsDtoMapper.toProductsBasicTypeResponseFromDomain(recommendationProducts);
 	}
 
+	public List<ProductBasicTypeResponse> findAllByBestCategory(String category) {
+		List<ProductEntity> productEntities =productsRepository.findAllByBestCategory(category);
+		List<DiscountPolicyEntity> discountPolicyEntities = discountPolicyRepository.findAll();
+		List<DeliveryPolicyEntity> deliveryPolicyEntities = deliveryPolicyRepository.findAll();
+
+		List<Product> products = domainEntityMapper.toDomainFromProductsEntity(productEntities,
+			discountPolicyEntities,
+			deliveryPolicyEntities);
+
+		validateProducts(products);
+
+		return productsDtoMapper.toProductsBasicTypeResponseFromDomain(products);
+	}
+
+	private void validateProducts(List<Product> products) {
+		if (products.isEmpty()) {
+			throw new NoSuchProductsException();
+		}
+	}
+
 	private List<ProductEntity> recommendProducts(List<ProductEntity> productEntities) {
 		Collections.shuffle(productEntities);
 
 		return productEntities.subList(0, 11);
-	}
-	public List<ProductBasicTypeResponse> findAllByBestCategory(String meat) {
-		return null;
 	}
 }

--- a/BE/src/main/java/sidedish/com/service/ProductsService.java
+++ b/BE/src/main/java/sidedish/com/service/ProductsService.java
@@ -86,4 +86,7 @@ public class ProductsService {
 
 		return productEntities.subList(0, 11);
 	}
+	public List<ProductBasicTypeResponse> findAllByBestCategory(String meat) {
+		return null;
+	}
 }

--- a/BE/src/test/java/sidedish/com/acceptancetest/ProductsAcceptanceTest.java
+++ b/BE/src/test/java/sidedish/com/acceptancetest/ProductsAcceptanceTest.java
@@ -111,4 +111,61 @@ class ProductsAcceptanceTest {
 			.statusCode(HttpStatus.NOT_FOUND.value());
 	}
 
+	@Test
+	void 만약_category가_meat인_경우_best_category가_meat인_음식_조회_성공() {
+		given()
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+
+			.when()
+			.get("/api/products/best?category=meat")
+
+			.then()
+			.statusCode(HttpStatus.OK.value())
+			.assertThat()
+			.body("[0].id", equalTo(1))
+			.body("[0].image", containsString("s3"))
+			.body("[0].productName", equalTo("오리주물럭"))
+			.body("[0].description", equalTo("감칠맛 나는 매콤한 양념"))
+			.body("[0].event", equalTo("런칭특가"))
+			.body("[0].fixedPrice", equalTo(14220))
+			.body("[0].originalPrice", equalTo(15800))
+			.body("[1].id", equalTo(3))
+			.body("[1].image", containsString("s3"))
+			.body("[1].productName", equalTo("소갈비찜"))
+			.body("[1].description", equalTo("촉촉하게 밴 양념이 일품"))
+			.body("[1].event", equalTo("이벤트특가"))
+			.body("[1].fixedPrice", equalTo(23120))
+			.body("[1].originalPrice", equalTo(28900))
+			.body("[2].id", equalTo(5))
+			.body("[2].image", containsString("s3"))
+			.body("[2].productName", equalTo("한돈 돼지 김치찌개"))
+			.body("[2].description", equalTo("김치찌개에는 역시 돼지고기"))
+			.body("[2].event", equalTo("이벤트특가"))
+			.body("[2].fixedPrice", equalTo(7440))
+			.body("[2].originalPrice", equalTo(9300));
+	}
+
+	@Test
+	void 만약_파라미터인_category를_입력하지_않은_경우_베스트_카테고리_음식_조회_실패() {
+		given()
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+
+			.when()
+			.get("/api/products/best")
+
+			.then()
+			.statusCode(HttpStatus.BAD_REQUEST.value());
+	}
+
+	@Test
+	void 만약_category의_값이_유효하지_않는_경우_조회_실패() {
+		given()
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+
+			.when()
+			.get("/api/products/best?category=abc")
+
+			.then()
+			.statusCode(HttpStatus.NOT_FOUND.value());
+	}
 }

--- a/BE/src/test/java/sidedish/com/controller/ProductsControllerTest.java
+++ b/BE/src/test/java/sidedish/com/controller/ProductsControllerTest.java
@@ -62,6 +62,18 @@ class ProductsControllerTest {
 			.andExpect(content().contentType(MediaType.APPLICATION_JSON));
 	}
 
+	@Test
+	void 만약_category가_meat인_경우_베스트_음식_중_meat_타입_조회_성공() throws Exception {
+		given(productsService.findAllByBestCategory("meat"))
+			.willReturn(createProductsMealTypeResponse());
+
+		ResultActions perform = mockMvc.perform(get("/api/products/best?category=meat"));
+
+		perform
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+	}
+
 	private List<ProductBasicTypeResponse> createProductsMealTypeResponse() {
 		List<Product> products = new ArrayList<>();
 
@@ -78,4 +90,6 @@ class ProductsControllerTest {
 
 		return productsDtoMapper.toProductsBasicTypeResponseFromDomain(products);
 	}
+
+
 }

--- a/BE/src/test/java/sidedish/com/repository/ProductsRepositoryTest.java
+++ b/BE/src/test/java/sidedish/com/repository/ProductsRepositoryTest.java
@@ -101,4 +101,68 @@ class ProductsRepositoryTest  {
 	    }
 	}
 
+	@Nested
+	@DisplayName("findAllByBestCategory(String Category) 메서드")
+	class Describe_findAllByBestCategory {
+
+		@Nested
+		@DisplayName("만약 category가 유효한 meat로 주어진다면")
+		class Context_with__category_is_meat {
+
+			@Test
+			@DisplayName("category가 meat인 모든 Product의 List를 반환한다")
+			void It_returns_products_best_category_meat() {
+				List<ProductEntity> result = productsRepository.findAllByBestCategory("meat");
+				ProductEntity sut = result.get(0);
+
+				assertThat(result.size()).isEqualTo(3);
+				assertThat(sut.getBestCategory()).isEqualTo("meat");
+			}
+		}
+
+		@Nested
+		@DisplayName("만약 category가 유효한 easy로 주어진다면")
+		class Context_with__category_is_easy {
+
+			@Test
+			@DisplayName("category가 easy인 모든 Product의 List를 반환한다")
+			void It_returns_products_best_category_easy() {
+				List<ProductEntity> result = productsRepository.findAllByBestCategory("easy");
+				ProductEntity sut = result.get(0);
+
+				assertThat(result.size()).isEqualTo(3);
+				assertThat(sut.getBestCategory()).isEqualTo("easy");
+			}
+		}
+
+		@Nested
+		@DisplayName("만약 category가 유효한 season으로 주어진다면")
+		class Context_with__category_is_season {
+
+			@Test
+			@DisplayName("category가 season인 모든 Product의 List를 반환한다")
+			void It_returns_products_best_category_season() {
+				List<ProductEntity> result = productsRepository.findAllByBestCategory("season");
+				ProductEntity sut = result.get(0);
+
+				assertThat(result.size()).isEqualTo(2);
+				assertThat(sut.getBestCategory()).isEqualTo("season");
+			}
+		}
+
+		@Nested
+		@DisplayName("만약 category가 유효한 kids으로 주어진다면")
+		class Context_with__category_is_kids {
+
+			@Test
+			@DisplayName("category가 kids인 모든 Product의 List를 반환한다")
+			void It_returns_products_best_category_kids() {
+				List<ProductEntity> result = productsRepository.findAllByBestCategory("kids");
+				ProductEntity sut = result.get(0);
+
+				assertThat(result.size()).isEqualTo(2);
+				assertThat(sut.getBestCategory()).isEqualTo("kids");
+			}
+		}
+	}
 }


### PR DESCRIPTION
### Description
특정 카테고리의 베스트 음식을 조회할 수 있게 구현했습니다.
`API : GET /api/products/best?category={value}`
- category의 4가지 value : `meat`, `easy`, `season`, `kids`

### Commits
- 특정 카테고리의 베스트 음식 조회 기능 구현

#### 테스트
- 컨트롤러 테스트 구현
- 인수테스트 구현
- 리파지토리 테스트 구현

#### 리팩터링
- `@Repository` 어노테이션 제거
- `discountRate` 자료형 `float`에서 `long`으로 변경
- `validProducts` 메서드 이름 `validateProducts`로 이름 변경
